### PR TITLE
fix #6: unlock read after peer session created

### DIFF
--- a/mod_wsbridge/mod_wsbridge.c
+++ b/mod_wsbridge/mod_wsbridge.c
@@ -1031,6 +1031,8 @@ static switch_status_t channel_on_exchange_media(switch_core_session_t *session)
 	tech_pvt->rate_rtp = read_impl.actual_samples_per_second;                   
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Sample rate on the RTP side: [%d]\n", tech_pvt->rate_rtp);
 
+	switch_core_session_rwunlock(peer_session);
+	
 	return SWITCH_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
As talked in the comments of [this webpage](https://freeswitch.org/jira/si/jira.issueviews:issue-html/FS-3608/FS-3608.html), `switch_core_session_rwunlock` must be called on any session created with `session_locate` or originate or it will remain read locked and will never be able to be destroyed.