### PR TITLE
[OPENTOK-46374] Custom headers not being received in Secure WS

### DIFF
--- a/mod_wsbridge/mod_wsbridge.c
+++ b/mod_wsbridge/mod_wsbridge.c
@@ -855,10 +855,6 @@ static switch_status_t channel_on_init(switch_core_session_t *session)
 	assert(channel != NULL);
 	switch_set_flag_locked(tech_pvt, TFLAG_IO);
 
-	switch_mutex_lock(globals.mutex);
-	globals.calls++;
-	switch_mutex_unlock(globals.mutex);
-
 	if (cJSON_GetArraySize(tech_pvt->message) == 1 && cJSON_GetObjectItem(tech_pvt->message, "content-type")) {
 		cJSON* json_req = NULL;
 		if ((json_req = get_ws_headers(channel))) {
@@ -873,6 +869,10 @@ static switch_status_t channel_on_init(switch_core_session_t *session)
 		}
 	}
 
+	switch_mutex_lock(globals.mutex);
+	globals.calls++;
+	switch_mutex_unlock(globals.mutex);
+	
 	switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_INFO, "WSBridge: number of current calls: %d\n", globals.calls);
 
 	return SWITCH_STATUS_SUCCESS;


### PR DESCRIPTION
When using ssl, we lock the WebSocket client connection establishment with globals.mutex, then on channel init at the beginning we lock also with globals.mutex to increase the counter for the number of calls and after that we modify the first message. Since it's being locked only for WSS the channel init logic for adding the headers is not being done in proper timing (The lock can only be acquired once websocket is established).

Fix: change locking to be done after the object is modified.